### PR TITLE
Remove debug! macros incompatible w/ hdk3

### DIFF
--- a/crates/hc-utils/src/commit_idempotent.rs
+++ b/crates/hc-utils/src/commit_idempotent.rs
@@ -5,7 +5,6 @@ use hdk3::prelude::*;
 /// Query for an existing Entry in the local source-chain matching the given EntryType name(s).  If
 /// one exists, return it Address, otherwise commit it.
 pub fn commit_idempotent(entry_id: String, value: Entry) -> UtilsResult<HeaderHash> {
-    debug!("Iterate through chain ")?;
     for element in local_source_chain().unwrap().0 {
         if let element::ElementEntry::Present(entry) = element.entry() {
             if entry.clone() == value {
@@ -13,7 +12,6 @@ pub fn commit_idempotent(entry_id: String, value: Entry) -> UtilsResult<HeaderHa
             }
         }
     }
-    debug!("Creating entry...")?;
     let result = create(EntryDefId::App(entry_id), value)?;
     Ok(result)
 }

--- a/crates/hc-utils/src/exists.rs
+++ b/crates/hc-utils/src/exists.rs
@@ -5,7 +5,6 @@ use hdk3::prelude::*;
 /// Query for an existing Entry in the local source-chain matching the given EntryType name(s).  If
 /// one exists, return it Address, otherwise returns error.
 pub fn exists(value: Entry) -> UtilsResult<HeaderHash> {
-    debug!("Searching entry...")?;
     for element in local_source_chain().unwrap().0 {
         if let element::ElementEntry::Present(entry) = element.entry() {
             if entry.clone() == value {
@@ -13,6 +12,5 @@ pub fn exists(value: Entry) -> UtilsResult<HeaderHash> {
             }
         }
     }
-    debug!("Entry does not exist...")?;
     return Err(UtilsError::EntryNotFound);
 }

--- a/crates/hc-utils/src/local_source_chain.rs
+++ b/crates/hc-utils/src/local_source_chain.rs
@@ -2,8 +2,6 @@ use crate::error::*;
 use hdk3::prelude::*;
 
 pub fn local_source_chain() -> UtilsResult<ElementVec> {
-    debug!("Getting local chain.")?;
-
     let filter = QueryFilter::new();
     let with_entry_filter = filter.include_entries(true);
 
@@ -16,6 +14,5 @@ pub fn local_source_chain() -> UtilsResult<ElementVec> {
 
     let header_filter = with_entry_filter.header_type(HeaderType::Create);
     let query_result: ElementVec = query(header_filter)?;
-    debug!("returning local source chain.")?;
     Ok(query_result)
 }


### PR DESCRIPTION
The current version of holochain hdk3 doesn't support `debug!(...)?;`.

I've removed these (instead of just removing the `?`), because they're probably not necessary for debugging these utility functions anymore.