### PR TITLE
Allow UtilsErrors to be compared for equality, for Rust testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ opt-level = "z"
 
 [profile.release]
 opt-level = "z"
+
+[patch.crates-io]
+hdk3 = {git = "https://github.com/holochain/holochain", rev = "78adfa99cda284f254d6e3c8ee76b74ed7de49a6", package = "hdk3"}
+holo_hash = {git = "https://github.com/holochain/holochain", rev = "78adfa99cda284f254d6e3c8ee76b74ed7de49a6", package = "holo_hash"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,3 @@ opt-level = "z"
 
 [profile.release]
 opt-level = "z"
-
-[patch.crates-io]
-hdk3 = {git = "https://github.com/holochain/holochain", rev = "78adfa99cda284f254d6e3c8ee76b74ed7de49a6", package = "hdk3"}
-holo_hash = {git = "https://github.com/holochain/holochain", rev = "78adfa99cda284f254d6e3c8ee76b74ed7de49a6", package = "holo_hash"}

--- a/crates/hc-utils/Cargo.toml
+++ b/crates/hc-utils/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 serde = "=1.0.104"
 # hdk3 = { path = "../../../holochain/crates/hdk" }
 # hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "3dd53e4ca03c8c0815b4412ea8ebd16f2b19cd47", package = "hdk3" }
-hdk3 = "0"
+hdk = "0"
 # holo_hash = { git = "https://github.com/holochain/holochain.git", rev = "3dd53e4ca03c8c0815b4412ea8ebd16f2b19cd47", package = "holo_hash" }
 holo_hash = "0"
 thiserror = "1.0.22"

--- a/crates/hc-utils/Cargo.toml
+++ b/crates/hc-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hc_utils"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["zo-el <joel.ulahanna@holo.host>"]
 edition = "2018"
 

--- a/crates/hc-utils/src/commit_idempotent.rs
+++ b/crates/hc-utils/src/commit_idempotent.rs
@@ -12,7 +12,7 @@ pub fn commit_idempotent(entry_id: String, value: Entry) -> UtilsResult<HeaderHa
             }
         }
     }
-    let result = create(EntryDefId::App(entry_id), value)?;
+    let result = create(EntryWithDefId::new(EntryDefId::App(entry_id), value))?;
     Ok(result)
 }
 

--- a/crates/hc-utils/src/commit_idempotent.rs
+++ b/crates/hc-utils/src/commit_idempotent.rs
@@ -5,7 +5,7 @@ use hdk::prelude::*;
 /// Query for an existing Entry in the local source-chain matching the given EntryType name(s).  If
 /// one exists, return it Address, otherwise commit it.
 pub fn commit_idempotent(entry_id: String, value: Entry) -> UtilsResult<HeaderHash> {
-    for element in local_source_chain().unwrap() {
+    for element in local_source_chain()? {
         if let element::ElementEntry::Present(entry) = element.entry() {
             if entry.clone() == value {
                 return Ok(element.header_address().clone());

--- a/crates/hc-utils/src/commit_idempotent.rs
+++ b/crates/hc-utils/src/commit_idempotent.rs
@@ -1,6 +1,6 @@
 use crate::error::*;
 use crate::local_source_chain::local_source_chain;
-use hdk3::prelude::*;
+use hdk::prelude::*;
 
 /// Query for an existing Entry in the local source-chain matching the given EntryType name(s).  If
 /// one exists, return it Address, otherwise commit it.

--- a/crates/hc-utils/src/commit_idempotent.rs
+++ b/crates/hc-utils/src/commit_idempotent.rs
@@ -5,7 +5,7 @@ use hdk::prelude::*;
 /// Query for an existing Entry in the local source-chain matching the given EntryType name(s).  If
 /// one exists, return it Address, otherwise commit it.
 pub fn commit_idempotent(entry_id: String, value: Entry) -> UtilsResult<HeaderHash> {
-    for element in local_source_chain().unwrap().0 {
+    for element in local_source_chain().unwrap() {
         if let element::ElementEntry::Present(entry) = element.entry() {
             if entry.clone() == value {
                 return Ok(element.header_address().clone());

--- a/crates/hc-utils/src/error.rs
+++ b/crates/hc-utils/src/error.rs
@@ -8,8 +8,6 @@ pub enum UtilsError {
     EntryError(#[from] EntryError),
     #[error(transparent)]
     Wasm(#[from] WasmError),
-    #[error(transparent)]
-    HdkError(#[from] HdkError),
     #[error("Agent has not created a profile yet")]
     AgentNotRegisteredProfile,
     // #[error("Header that was just committed is missing. This means something went really wrong")]

--- a/crates/hc-utils/src/error.rs
+++ b/crates/hc-utils/src/error.rs
@@ -1,6 +1,6 @@
 use hdk::prelude::*;
 
-#[derive(thiserror::Error, Debug, Clone)]
+#[derive(thiserror::Error, Debug, Clone, PartialEq)]
 pub enum UtilsError {
     #[error(transparent)]
     Serialization(#[from] SerializedBytesError),

--- a/crates/hc-utils/src/error.rs
+++ b/crates/hc-utils/src/error.rs
@@ -1,4 +1,4 @@
-use hdk3::prelude::*;
+use hdk::prelude::*;
 
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum UtilsError {

--- a/crates/hc-utils/src/exists.rs
+++ b/crates/hc-utils/src/exists.rs
@@ -5,7 +5,7 @@ use hdk::prelude::*;
 /// Query for an existing Entry in the local source-chain matching the given EntryType name(s).  If
 /// one exists, return it Address, otherwise returns error.
 pub fn exists(value: Entry) -> UtilsResult<HeaderHash> {
-    for element in local_source_chain().unwrap().0 {
+    for element in local_source_chain().unwrap() {
         if let element::ElementEntry::Present(entry) = element.entry() {
             if entry.clone() == value {
                 return Ok(element.header_address().clone());

--- a/crates/hc-utils/src/exists.rs
+++ b/crates/hc-utils/src/exists.rs
@@ -1,6 +1,6 @@
 use crate::error::*;
 use crate::local_source_chain::local_source_chain;
-use hdk3::prelude::*;
+use hdk::prelude::*;
 
 /// Query for an existing Entry in the local source-chain matching the given EntryType name(s).  If
 /// one exists, return it Address, otherwise returns error.

--- a/crates/hc-utils/src/get_header.rs
+++ b/crates/hc-utils/src/get_header.rs
@@ -1,5 +1,5 @@
 use crate::error::*;
-use hdk3::prelude::*;
+use hdk::prelude::*;
 
 pub fn get_header(entry: EntryHash) -> UtilsResult<HeaderHash> {
     match get(entry, Default::default())? {

--- a/crates/hc-utils/src/get_latest_entry.rs
+++ b/crates/hc-utils/src/get_latest_entry.rs
@@ -1,4 +1,4 @@
-use hdk3::prelude::*;
+use hdk::prelude::*;
 use metadata::EntryDetails;
 enum Latest {
     Found(Entry),

--- a/crates/hc-utils/src/get_latest_entry.rs
+++ b/crates/hc-utils/src/get_latest_entry.rs
@@ -7,6 +7,13 @@ enum Latest {
 }
 use crate::error::*;
 
+/// Obtains the updates for the target Entry, and examines all of them to selects the latest one by
+/// looking at the update time in its header.
+/// 
+/// An identical Entry can be committed by multiple Agents; this obtains the Entry's Header from the
+/// perspective of *this* Agent.  It also may be committed by the same Agent multiple times, this
+/// algorithm depends on either making the Entry unique, *or* that the caller is OK with it
+/// returning the latest Update by any of this Agent's commits of this identical Entry.
 pub fn get_latest_entry(target: EntryHash, option: GetOptions) -> UtilsResult<Entry> {
     // Get the original
     let mut latest_profile = _get_latest_entry(target, option.clone())?;

--- a/crates/hc-utils/src/get_latest_link.rs
+++ b/crates/hc-utils/src/get_latest_link.rs
@@ -1,5 +1,5 @@
 use crate::error::*;
-use hdk3::prelude::*;
+use hdk::prelude::*;
 use link::Link;
 
 pub fn get_latest_link(base: EntryHash, tag: Option<LinkTag>) -> UtilsResult<Option<Link>> {

--- a/crates/hc-utils/src/get_links_and_load_type.rs
+++ b/crates/hc-utils/src/get_links_and_load_type.rs
@@ -1,6 +1,6 @@
 use crate::error::*;
 use crate::get_latest_entry::get_latest_entry;
-use hdk3::prelude::*;
+use hdk::prelude::*;
 use std::convert::TryFrom;
 
 pub fn get_links_and_load_type<R: TryFrom<Entry>>(

--- a/crates/hc-utils/src/local_source_chain.rs
+++ b/crates/hc-utils/src/local_source_chain.rs
@@ -1,5 +1,5 @@
 use crate::error::*;
-use hdk3::prelude::*;
+use hdk::prelude::*;
 
 pub fn local_source_chain() -> UtilsResult<ElementVec> {
     let filter = QueryFilter::new();

--- a/crates/hc-utils/src/local_source_chain.rs
+++ b/crates/hc-utils/src/local_source_chain.rs
@@ -13,6 +13,6 @@ pub fn local_source_chain() -> UtilsResult<ElementVec> {
     // )));
 
     let header_filter = with_entry_filter.header_type(HeaderType::Create);
-    let query_result: ElementVec = query(header_filter)?;
+    let query_result: Vec<Element> = query(header_filter)?;
     Ok(query_result)
 }

--- a/crates/hc-utils/src/local_source_chain.rs
+++ b/crates/hc-utils/src/local_source_chain.rs
@@ -1,7 +1,7 @@
 use crate::error::*;
 use hdk::prelude::*;
 
-pub fn local_source_chain() -> UtilsResult<ElementVec> {
+pub fn local_source_chain() -> UtilsResult<Vec<Element>> {
     let filter = QueryFilter::new();
     let with_entry_filter = filter.include_entries(true);
 

--- a/crates/hc-utils/src/wrappers.rs
+++ b/crates/hc-utils/src/wrappers.rs
@@ -1,4 +1,4 @@
-use hdk3::prelude::*;
+use hdk::prelude::*;
 use holo_hash::DnaHash;
 
 #[derive(Debug, Serialize, Deserialize, SerializedBytes, Clone, PartialEq)]


### PR DESCRIPTION
I also added some commentary to the get_latest_entry API.  It seems like this uses an EntryHash, and not a HeaderHash, to then perform a walk of the CRUD updates to the Entry.

Doesn't this depend on the Entry being unique in the DHT?  If an Agent commits multiple identical entries with the same EntryHash, and then commits CRUD updates to one (or more) of them, how does this implementation ensure that we follow the "expected" chain of CRUD updates -- don't we have to deterministically identify the specific HeaderHash of the one Entry commit we're concerned with, and follow (only) its CRUD updates?

Anyway, the additional PartialEq is required in order to support Rust unit-testing of calls that return Error implementations including a UtilError...