### PR TITLE
Point dependencies to crates 

### DIFF
--- a/crates/hc-utils/Cargo.toml
+++ b/crates/hc-utils/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 serde = "=1.0.123"
 # hdk3 = { path = "../../../holochain/crates/hdk" }
 # hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "3dd53e4ca03c8c0815b4412ea8ebd16f2b19cd47", package = "hdk3" }
-hdk = "0"
+hdk = "0.0.100-alpha.1"
 # holo_hash = { git = "https://github.com/holochain/holochain.git", rev = "3dd53e4ca03c8c0815b4412ea8ebd16f2b19cd47", package = "holo_hash" }
-holo_hash = "0"
+holo_hash = "0.0.2-alpha.1"
 thiserror = "1.0.22"
 
 [lib]


### PR DESCRIPTION
Hi! Without this there is not really a way to comsume the hc_utils library and point to the crates hdk upstream. If `hdk v0.0.100` lands soon, `hdk = "0"` will match, but not with the alpha yet. What do you think @zo-el ? 