### PR TITLE
URL Safe Wrapper

### DIFF
--- a/crates/hc-utils/Cargo.toml
+++ b/crates/hc-utils/Cargo.toml
@@ -12,6 +12,7 @@ hdk = "0.0.101-alpha.0"
 # holo_hash = { git = "https://github.com/holochain/holochain.git", rev = "3dd53e4ca03c8c0815b4412ea8ebd16f2b19cd47", package = "holo_hash" }
 holo_hash = "0.0.2-alpha.1"
 thiserror = "1.0.22"
+multibase = "0.9"
 
 [lib]
 name = "hc_utils"

--- a/crates/hc-utils/src/get_latest_entry.rs
+++ b/crates/hc-utils/src/get_latest_entry.rs
@@ -9,7 +9,7 @@ use crate::error::*;
 
 /// Obtains the updates for the target Entry, and examines all of them to selects the latest one by
 /// looking at the update time in its header.
-/// 
+///
 /// An identical Entry can be committed by multiple Agents; this obtains the Entry's Header from the
 /// perspective of *this* Agent.  It also may be committed by the same Agent multiple times, this
 /// algorithm depends on either making the Entry unique, *or* that the caller is OK with it

--- a/crates/hc-utils/src/lib.rs
+++ b/crates/hc-utils/src/lib.rs
@@ -24,3 +24,8 @@ pub use wrappers::WrappedAgentPubKey;
 pub use wrappers::WrappedDnaHash;
 pub use wrappers::WrappedEntryHash;
 pub use wrappers::WrappedHeaderHash;
+pub mod wrappers_url_safe;
+pub use wrappers_url_safe::SafeWrappedAgentPubKey;
+pub use wrappers_url_safe::SafeWrappedDnaHash;
+pub use wrappers_url_safe::SafeWrappedEntryHash;
+pub use wrappers_url_safe::SafeWrappedHeaderHash;

--- a/crates/hc-utils/src/wrappers.rs
+++ b/crates/hc-utils/src/wrappers.rs
@@ -1,5 +1,5 @@
-use hdk::prelude::*;
 use ::holo_hash::DnaHash;
+use hdk::prelude::*;
 
 #[derive(Debug, Serialize, Deserialize, SerializedBytes, Clone, PartialEq)]
 pub struct HashString(String);

--- a/crates/hc-utils/src/wrappers.rs
+++ b/crates/hc-utils/src/wrappers.rs
@@ -86,7 +86,7 @@ impl TryFrom<HashString> for WrappedDnaHash {
     }
 }
 impl From<WrappedDnaHash> for HashString {
-    fn from(wrapped_entry_hash: WrappedDnaHash) -> Self {
-        Self(wrapped_entry_hash.0.to_string())
+    fn from(wrapped_dna_hash: WrappedDnaHash) -> Self {
+        Self(wrapped_dna_hash.0.to_string())
     }
 }

--- a/crates/hc-utils/src/wrappers_url_safe.rs
+++ b/crates/hc-utils/src/wrappers_url_safe.rs
@@ -28,7 +28,7 @@ impl TryFrom<HashString> for SafeWrappedAgentPubKey {
     type Error = String;
     fn try_from(ui_string_hash: HashString) -> Result<Self, Self::Error> {
         let mut hash = ui_string_hash.0;
-        hash.replace_range(..3, "");
+        hash.replace_range(..4, "");
         assert_eq!(59, hash.len());
         match multibase::decode(hash) {
             Ok((_, bytes)) => Ok(Self(holo_hash::AgentPubKey::from_raw_36_and_type(bytes, holo_hash::hash_type::Agent))),
@@ -54,7 +54,7 @@ impl TryFrom<HashString> for SafeWrappedHeaderHash {
     type Error = String;
     fn try_from(ui_string_hash: HashString) -> Result<Self, Self::Error> {
         let mut hash = ui_string_hash.0;
-        hash.replace_range(..3, "");
+        hash.replace_range(..4, "");
         assert_eq!(59, hash.len());
         match multibase::decode(hash) {
             Ok((_, bytes)) => Ok(Self(holo_hash::HeaderHash::from_raw_36_and_type(bytes, holo_hash::hash_type::Header))),
@@ -73,7 +73,7 @@ impl TryFrom<HashString> for SafeWrappedEntryHash {
     type Error = String;
     fn try_from(ui_string_hash: HashString) -> Result<Self, Self::Error> {
         let mut hash = ui_string_hash.0;
-        hash.replace_range(..3, "");
+        hash.replace_range(..4, "");
         assert_eq!(59, hash.len());
         match multibase::decode(hash) {
             Ok((_, bytes)) => Ok(Self(holo_hash::EntryHash::from_raw_36_and_type(bytes, holo_hash::hash_type::Entry))),
@@ -92,7 +92,7 @@ impl TryFrom<HashString> for SafeWrappedDnaHash {
     type Error = String;
     fn try_from(ui_string_hash: HashString) -> Result<Self, Self::Error> {
         let mut hash = ui_string_hash.0;
-        hash.replace_range(..3, "");
+        hash.replace_range(..4, "");
         assert_eq!(59, hash.len());
         match multibase::decode(hash) {
             Ok((_, bytes)) => Ok(Self(holo_hash::DnaHash::from_raw_36_and_type(bytes, holo_hash::hash_type::Dna))),

--- a/crates/hc-utils/src/wrappers_url_safe.rs
+++ b/crates/hc-utils/src/wrappers_url_safe.rs
@@ -27,8 +27,10 @@ pub struct SafeWrappedDnaHash(pub DnaHash);
 impl TryFrom<HashString> for SafeWrappedAgentPubKey {
     type Error = String;
     fn try_from(ui_string_hash: HashString) -> Result<Self, Self::Error> {
-        assert_eq!(59, ui_string_hash.0.len());
-        match multibase::decode(ui_string_hash.0) {
+        let mut hash = ui_string_hash.0;
+        hash.replace_range(..3, "");
+        assert_eq!(59, hash.len());
+        match multibase::decode(hash) {
             Ok((_, bytes)) => Ok(Self(holo_hash::AgentPubKey::from_raw_36_and_type(bytes, holo_hash::hash_type::Agent))),
             Err(e) => Err(format!("{:?}", e)),
         }
@@ -43,15 +45,18 @@ impl From<SafeWrappedAgentPubKey> for AgentPubKey {
 
 impl From<SafeWrappedAgentPubKey> for HashString {
     fn from(wrapped_agent_pub_key: SafeWrappedAgentPubKey) -> Self {
-        Self(multibase::encode(multibase::Base::Base32Lower, &wrapped_agent_pub_key.0.get_raw_39()[3..]).to_string())
+        let hash = multibase::encode(multibase::Base::Base32Lower, &wrapped_agent_pub_key.0.get_raw_39()[3..]);
+        Self(format!("hcak{}", hash.to_string()))
     }
 }
 
 impl TryFrom<HashString> for SafeWrappedHeaderHash {
     type Error = String;
     fn try_from(ui_string_hash: HashString) -> Result<Self, Self::Error> {
-        assert_eq!(59, ui_string_hash.0.len());
-        match multibase::decode(ui_string_hash.0) {
+        let mut hash = ui_string_hash.0;
+        hash.replace_range(..3, "");
+        assert_eq!(59, hash.len());
+        match multibase::decode(hash) {
             Ok((_, bytes)) => Ok(Self(holo_hash::HeaderHash::from_raw_36_and_type(bytes, holo_hash::hash_type::Header))),
             Err(e) => Err(format!("{:?}", e)),
         }
@@ -59,15 +64,18 @@ impl TryFrom<HashString> for SafeWrappedHeaderHash {
 }
 impl From<SafeWrappedHeaderHash> for HashString {
     fn from(wrapped_header_hash: SafeWrappedHeaderHash) -> Self {
-        Self(multibase::encode(multibase::Base::Base32Lower, &wrapped_header_hash.0.get_raw_39()[3..]).to_string())
+        let hash = multibase::encode(multibase::Base::Base32Lower, &wrapped_header_hash.0.get_raw_39()[3..]);
+        Self(format!("hckk{}", hash.to_string()))
     }
 }
 
 impl TryFrom<HashString> for SafeWrappedEntryHash {
     type Error = String;
     fn try_from(ui_string_hash: HashString) -> Result<Self, Self::Error> {
-        assert_eq!(59, ui_string_hash.0.len());
-        match multibase::decode(ui_string_hash.0) {
+        let mut hash = ui_string_hash.0;
+        hash.replace_range(..3, "");
+        assert_eq!(59, hash.len());
+        match multibase::decode(hash) {
             Ok((_, bytes)) => Ok(Self(holo_hash::EntryHash::from_raw_36_and_type(bytes, holo_hash::hash_type::Entry))),
             Err(e) => Err(format!("{:?}", e)),
         }
@@ -75,15 +83,18 @@ impl TryFrom<HashString> for SafeWrappedEntryHash {
 }
 impl From<SafeWrappedEntryHash> for HashString {
     fn from(wrapped_entry_hash: SafeWrappedEntryHash) -> Self {
-        Self(multibase::encode(multibase::Base::Base32Lower, &wrapped_entry_hash.0.get_raw_39()[3..]).to_string())
+        let hash = multibase::encode(multibase::Base::Base32Lower, &wrapped_entry_hash.0.get_raw_39()[3..]);
+        Self(format!("hcek{}", hash.to_string()))
     }
 }
 
 impl TryFrom<HashString> for SafeWrappedDnaHash {
     type Error = String;
     fn try_from(ui_string_hash: HashString) -> Result<Self, Self::Error> {
-        assert_eq!(59, ui_string_hash.0.len());
-        match multibase::decode(ui_string_hash.0) {
+        let mut hash = ui_string_hash.0;
+        hash.replace_range(..3, "");
+        assert_eq!(59, hash.len());
+        match multibase::decode(hash) {
             Ok((_, bytes)) => Ok(Self(holo_hash::DnaHash::from_raw_36_and_type(bytes, holo_hash::hash_type::Dna))),
             Err(e) => Err(format!("{:?}", e)),
         }
@@ -91,6 +102,7 @@ impl TryFrom<HashString> for SafeWrappedDnaHash {
 }
 impl From<SafeWrappedDnaHash> for HashString {
     fn from(wrapped_dna_hash: SafeWrappedDnaHash) -> Self {
-        Self(multibase::encode(multibase::Base::Base32Lower, &wrapped_dna_hash.0.get_raw_39()[3..]).to_string())
+        let hash = multibase::encode(multibase::Base::Base32Lower, &wrapped_dna_hash.0.get_raw_39()[3..]);
+        Self(format!("hc0k{}", hash.to_string()))
     }
 }

--- a/crates/hc-utils/src/wrappers_url_safe.rs
+++ b/crates/hc-utils/src/wrappers_url_safe.rs
@@ -1,5 +1,5 @@
-use hdk::prelude::*;
 use ::holo_hash::DnaHash;
+use hdk::prelude::*;
 
 #[derive(Debug, Serialize, Deserialize, SerializedBytes, Clone, PartialEq)]
 pub struct HashString(String);
@@ -24,6 +24,11 @@ pub struct SafeWrappedEntryHash(pub EntryHash);
 #[serde(into = "HashString")]
 pub struct SafeWrappedDnaHash(pub DnaHash);
 
+const AGENT_PREFIX: &str = "hcak";
+const HEADER_PREFIX: &str = "hckk";
+const ENTRY_PREFIX: &str = "hcek";
+const DNA_PREFIX: &str = "hc0k";
+
 impl TryFrom<HashString> for SafeWrappedAgentPubKey {
     type Error = String;
     fn try_from(ui_string_hash: HashString) -> Result<Self, Self::Error> {
@@ -32,7 +37,10 @@ impl TryFrom<HashString> for SafeWrappedAgentPubKey {
             hash.replace_range(..4, "");
             assert_eq!(59, hash.len());
             match multibase::decode(hash) {
-                Ok((_, bytes)) => Ok(Self(holo_hash::AgentPubKey::from_raw_36_and_type(bytes, holo_hash::hash_type::Agent))),
+                Ok((_, bytes)) => Ok(Self(holo_hash::AgentPubKey::from_raw_36_and_type(
+                    bytes,
+                    holo_hash::hash_type::Agent,
+                ))),
                 Err(e) => Err(format!("{:?}", e)),
             }
         } else {
@@ -40,14 +48,13 @@ impl TryFrom<HashString> for SafeWrappedAgentPubKey {
         }
     }
 }
-const AGENT_PREFIX: &str = "hcak";
-const HEADER_PREFIX: &str = "hckk";
-const ENTRY_PREFIX: &str = "hcek";
-const DNA_PREFIX: &str = "hc0k";
 
 impl From<SafeWrappedAgentPubKey> for HashString {
     fn from(wrapped_agent_pub_key: SafeWrappedAgentPubKey) -> Self {
-        let hash = multibase::encode(multibase::Base::Base32Lower, &wrapped_agent_pub_key.0.get_raw_39()[3..]);
+        let hash = multibase::encode(
+            multibase::Base::Base32Lower,
+            &wrapped_agent_pub_key.0.get_raw_39()[3..],
+        );
         Self(format!("{}{}", AGENT_PREFIX, hash.to_string()))
     }
 }
@@ -60,7 +67,10 @@ impl TryFrom<HashString> for SafeWrappedHeaderHash {
             hash.replace_range(..4, "");
             assert_eq!(59, hash.len());
             match multibase::decode(hash) {
-                Ok((_, bytes)) => Ok(Self(holo_hash::HeaderHash::from_raw_36_and_type(bytes, holo_hash::hash_type::Header))),
+                Ok((_, bytes)) => Ok(Self(holo_hash::HeaderHash::from_raw_36_and_type(
+                    bytes,
+                    holo_hash::hash_type::Header,
+                ))),
                 Err(e) => Err(format!("{:?}", e)),
             }
         } else {
@@ -70,7 +80,10 @@ impl TryFrom<HashString> for SafeWrappedHeaderHash {
 }
 impl From<SafeWrappedHeaderHash> for HashString {
     fn from(wrapped_header_hash: SafeWrappedHeaderHash) -> Self {
-        let hash = multibase::encode(multibase::Base::Base32Lower, &wrapped_header_hash.0.get_raw_39()[3..]);
+        let hash = multibase::encode(
+            multibase::Base::Base32Lower,
+            &wrapped_header_hash.0.get_raw_39()[3..],
+        );
         Self(format!("{}{}", HEADER_PREFIX, hash.to_string()))
     }
 }
@@ -83,7 +96,10 @@ impl TryFrom<HashString> for SafeWrappedEntryHash {
             hash.replace_range(..4, "");
             assert_eq!(59, hash.len());
             match multibase::decode(hash) {
-                Ok((_, bytes)) => Ok(Self(holo_hash::EntryHash::from_raw_36_and_type(bytes, holo_hash::hash_type::Entry))),
+                Ok((_, bytes)) => Ok(Self(holo_hash::EntryHash::from_raw_36_and_type(
+                    bytes,
+                    holo_hash::hash_type::Entry,
+                ))),
                 Err(e) => Err(format!("{:?}", e)),
             }
         } else {
@@ -93,7 +109,10 @@ impl TryFrom<HashString> for SafeWrappedEntryHash {
 }
 impl From<SafeWrappedEntryHash> for HashString {
     fn from(wrapped_entry_hash: SafeWrappedEntryHash) -> Self {
-        let hash = multibase::encode(multibase::Base::Base32Lower, &wrapped_entry_hash.0.get_raw_39()[3..]);
+        let hash = multibase::encode(
+            multibase::Base::Base32Lower,
+            &wrapped_entry_hash.0.get_raw_39()[3..],
+        );
         Self(format!("{}{}", ENTRY_PREFIX, hash.to_string()))
     }
 }
@@ -106,7 +125,10 @@ impl TryFrom<HashString> for SafeWrappedDnaHash {
             hash.replace_range(..4, "");
             assert_eq!(59, hash.len());
             match multibase::decode(hash) {
-                Ok((_, bytes)) => Ok(Self(holo_hash::DnaHash::from_raw_36_and_type(bytes, holo_hash::hash_type::Dna))),
+                Ok((_, bytes)) => Ok(Self(holo_hash::DnaHash::from_raw_36_and_type(
+                    bytes,
+                    holo_hash::hash_type::Dna,
+                ))),
                 Err(e) => Err(format!("{:?}", e)),
             }
         } else {
@@ -116,7 +138,10 @@ impl TryFrom<HashString> for SafeWrappedDnaHash {
 }
 impl From<SafeWrappedDnaHash> for HashString {
     fn from(wrapped_dna_hash: SafeWrappedDnaHash) -> Self {
-        let hash = multibase::encode(multibase::Base::Base32Lower, &wrapped_dna_hash.0.get_raw_39()[3..]);
+        let hash = multibase::encode(
+            multibase::Base::Base32Lower,
+            &wrapped_dna_hash.0.get_raw_39()[3..],
+        );
         Self(format!("{}{}", DNA_PREFIX, hash.to_string()))
     }
 }

--- a/crates/hc-utils/src/wrappers_url_safe.rs
+++ b/crates/hc-utils/src/wrappers_url_safe.rs
@@ -28,25 +28,27 @@ impl TryFrom<HashString> for SafeWrappedAgentPubKey {
     type Error = String;
     fn try_from(ui_string_hash: HashString) -> Result<Self, Self::Error> {
         let mut hash = ui_string_hash.0;
-        hash.replace_range(..4, "");
-        assert_eq!(59, hash.len());
-        match multibase::decode(hash) {
-            Ok((_, bytes)) => Ok(Self(holo_hash::AgentPubKey::from_raw_36_and_type(bytes, holo_hash::hash_type::Agent))),
-            Err(e) => Err(format!("{:?}", e)),
+        if &hash[..4] == AGENT_PREFIX {
+            hash.replace_range(..4, "");
+            assert_eq!(59, hash.len());
+            match multibase::decode(hash) {
+                Ok((_, bytes)) => Ok(Self(holo_hash::AgentPubKey::from_raw_36_and_type(bytes, holo_hash::hash_type::Agent))),
+                Err(e) => Err(format!("{:?}", e)),
+            }
+        } else {
+            Err(format!("Invalid AgentPubKey received {:?}", hash))
         }
     }
 }
-
-impl From<SafeWrappedAgentPubKey> for AgentPubKey {
-    fn from(ui_string_hash: SafeWrappedAgentPubKey) -> Self {
-        return ui_string_hash.0;
-    }
-}
+const AGENT_PREFIX: &str = "hcak";
+const HEADER_PREFIX: &str = "hckk";
+const ENTRY_PREFIX: &str = "hcek";
+const DNA_PREFIX: &str = "hc0k";
 
 impl From<SafeWrappedAgentPubKey> for HashString {
     fn from(wrapped_agent_pub_key: SafeWrappedAgentPubKey) -> Self {
         let hash = multibase::encode(multibase::Base::Base32Lower, &wrapped_agent_pub_key.0.get_raw_39()[3..]);
-        Self(format!("hcak{}", hash.to_string()))
+        Self(format!("{}{}", AGENT_PREFIX, hash.to_string()))
     }
 }
 
@@ -54,18 +56,22 @@ impl TryFrom<HashString> for SafeWrappedHeaderHash {
     type Error = String;
     fn try_from(ui_string_hash: HashString) -> Result<Self, Self::Error> {
         let mut hash = ui_string_hash.0;
-        hash.replace_range(..4, "");
-        assert_eq!(59, hash.len());
-        match multibase::decode(hash) {
-            Ok((_, bytes)) => Ok(Self(holo_hash::HeaderHash::from_raw_36_and_type(bytes, holo_hash::hash_type::Header))),
-            Err(e) => Err(format!("{:?}", e)),
+        if &hash[..4] == HEADER_PREFIX {
+            hash.replace_range(..4, "");
+            assert_eq!(59, hash.len());
+            match multibase::decode(hash) {
+                Ok((_, bytes)) => Ok(Self(holo_hash::HeaderHash::from_raw_36_and_type(bytes, holo_hash::hash_type::Header))),
+                Err(e) => Err(format!("{:?}", e)),
+            }
+        } else {
+            Err(format!("Invalid HeaderHash received {:?}", hash))
         }
     }
 }
 impl From<SafeWrappedHeaderHash> for HashString {
     fn from(wrapped_header_hash: SafeWrappedHeaderHash) -> Self {
         let hash = multibase::encode(multibase::Base::Base32Lower, &wrapped_header_hash.0.get_raw_39()[3..]);
-        Self(format!("hckk{}", hash.to_string()))
+        Self(format!("{}{}", HEADER_PREFIX, hash.to_string()))
     }
 }
 
@@ -73,18 +79,22 @@ impl TryFrom<HashString> for SafeWrappedEntryHash {
     type Error = String;
     fn try_from(ui_string_hash: HashString) -> Result<Self, Self::Error> {
         let mut hash = ui_string_hash.0;
-        hash.replace_range(..4, "");
-        assert_eq!(59, hash.len());
-        match multibase::decode(hash) {
-            Ok((_, bytes)) => Ok(Self(holo_hash::EntryHash::from_raw_36_and_type(bytes, holo_hash::hash_type::Entry))),
-            Err(e) => Err(format!("{:?}", e)),
+        if &hash[..4] == ENTRY_PREFIX {
+            hash.replace_range(..4, "");
+            assert_eq!(59, hash.len());
+            match multibase::decode(hash) {
+                Ok((_, bytes)) => Ok(Self(holo_hash::EntryHash::from_raw_36_and_type(bytes, holo_hash::hash_type::Entry))),
+                Err(e) => Err(format!("{:?}", e)),
+            }
+        } else {
+            Err(format!("Invalid HeaderHash received {:?}", hash))
         }
     }
 }
 impl From<SafeWrappedEntryHash> for HashString {
     fn from(wrapped_entry_hash: SafeWrappedEntryHash) -> Self {
         let hash = multibase::encode(multibase::Base::Base32Lower, &wrapped_entry_hash.0.get_raw_39()[3..]);
-        Self(format!("hcek{}", hash.to_string()))
+        Self(format!("{}{}", ENTRY_PREFIX, hash.to_string()))
     }
 }
 
@@ -92,17 +102,21 @@ impl TryFrom<HashString> for SafeWrappedDnaHash {
     type Error = String;
     fn try_from(ui_string_hash: HashString) -> Result<Self, Self::Error> {
         let mut hash = ui_string_hash.0;
-        hash.replace_range(..4, "");
-        assert_eq!(59, hash.len());
-        match multibase::decode(hash) {
-            Ok((_, bytes)) => Ok(Self(holo_hash::DnaHash::from_raw_36_and_type(bytes, holo_hash::hash_type::Dna))),
-            Err(e) => Err(format!("{:?}", e)),
+        if &hash[..4] == DNA_PREFIX {
+            hash.replace_range(..4, "");
+            assert_eq!(59, hash.len());
+            match multibase::decode(hash) {
+                Ok((_, bytes)) => Ok(Self(holo_hash::DnaHash::from_raw_36_and_type(bytes, holo_hash::hash_type::Dna))),
+                Err(e) => Err(format!("{:?}", e)),
+            }
+        } else {
+            Err(format!("Invalid HeaderHash received {:?}", hash))
         }
     }
 }
 impl From<SafeWrappedDnaHash> for HashString {
     fn from(wrapped_dna_hash: SafeWrappedDnaHash) -> Self {
         let hash = multibase::encode(multibase::Base::Base32Lower, &wrapped_dna_hash.0.get_raw_39()[3..]);
-        Self(format!("hc0k{}", hash.to_string()))
+        Self(format!("{}{}", DNA_PREFIX, hash.to_string()))
     }
 }

--- a/crates/hc-utils/src/wrappers_url_safe.rs
+++ b/crates/hc-utils/src/wrappers_url_safe.rs
@@ -1,0 +1,96 @@
+use hdk::prelude::*;
+use ::holo_hash::DnaHash;
+
+#[derive(Debug, Serialize, Deserialize, SerializedBytes, Clone, PartialEq)]
+pub struct HashString(String);
+
+#[derive(Hash, Eq, Debug, Serialize, Deserialize, SerializedBytes, Clone, PartialEq)]
+#[serde(try_from = "HashString")]
+#[serde(into = "HashString")]
+pub struct SafeWrappedAgentPubKey(pub AgentPubKey);
+
+#[derive(Hash, Eq, Debug, Serialize, Deserialize, SerializedBytes, Clone, PartialEq)]
+#[serde(try_from = "HashString")]
+#[serde(into = "HashString")]
+pub struct SafeWrappedHeaderHash(pub HeaderHash);
+
+#[derive(Hash, Eq, Debug, Serialize, Deserialize, SerializedBytes, Clone, PartialEq)]
+#[serde(try_from = "HashString")]
+#[serde(into = "HashString")]
+pub struct SafeWrappedEntryHash(pub EntryHash);
+
+#[derive(Hash, Eq, Debug, Serialize, Deserialize, SerializedBytes, Clone, PartialEq)]
+#[serde(try_from = "HashString")]
+#[serde(into = "HashString")]
+pub struct SafeWrappedDnaHash(pub DnaHash);
+
+impl TryFrom<HashString> for SafeWrappedAgentPubKey {
+    type Error = String;
+    fn try_from(ui_string_hash: HashString) -> Result<Self, Self::Error> {
+        assert_eq!(59, ui_string_hash.0.len());
+        match multibase::decode(ui_string_hash.0) {
+            Ok((_, bytes)) => Ok(Self(holo_hash::AgentPubKey::from_raw_36_and_type(bytes, holo_hash::hash_type::Agent))),
+            Err(e) => Err(format!("{:?}", e)),
+        }
+    }
+}
+
+impl From<SafeWrappedAgentPubKey> for AgentPubKey {
+    fn from(ui_string_hash: SafeWrappedAgentPubKey) -> Self {
+        return ui_string_hash.0;
+    }
+}
+
+impl From<SafeWrappedAgentPubKey> for HashString {
+    fn from(wrapped_agent_pub_key: SafeWrappedAgentPubKey) -> Self {
+        Self(multibase::encode(multibase::Base::Base32Lower, &wrapped_agent_pub_key.0.get_raw_39()[3..]).to_string())
+    }
+}
+
+impl TryFrom<HashString> for SafeWrappedHeaderHash {
+    type Error = String;
+    fn try_from(ui_string_hash: HashString) -> Result<Self, Self::Error> {
+        assert_eq!(59, ui_string_hash.0.len());
+        match multibase::decode(ui_string_hash.0) {
+            Ok((_, bytes)) => Ok(Self(holo_hash::HeaderHash::from_raw_36_and_type(bytes, holo_hash::hash_type::Header))),
+            Err(e) => Err(format!("{:?}", e)),
+        }
+    }
+}
+impl From<SafeWrappedHeaderHash> for HashString {
+    fn from(wrapped_header_hash: SafeWrappedHeaderHash) -> Self {
+        Self(multibase::encode(multibase::Base::Base32Lower, &wrapped_header_hash.0.get_raw_39()[3..]).to_string())
+    }
+}
+
+impl TryFrom<HashString> for SafeWrappedEntryHash {
+    type Error = String;
+    fn try_from(ui_string_hash: HashString) -> Result<Self, Self::Error> {
+        assert_eq!(59, ui_string_hash.0.len());
+        match multibase::decode(ui_string_hash.0) {
+            Ok((_, bytes)) => Ok(Self(holo_hash::EntryHash::from_raw_36_and_type(bytes, holo_hash::hash_type::Entry))),
+            Err(e) => Err(format!("{:?}", e)),
+        }
+    }
+}
+impl From<SafeWrappedEntryHash> for HashString {
+    fn from(wrapped_entry_hash: SafeWrappedEntryHash) -> Self {
+        Self(multibase::encode(multibase::Base::Base32Lower, &wrapped_entry_hash.0.get_raw_39()[3..]).to_string())
+    }
+}
+
+impl TryFrom<HashString> for SafeWrappedDnaHash {
+    type Error = String;
+    fn try_from(ui_string_hash: HashString) -> Result<Self, Self::Error> {
+        assert_eq!(59, ui_string_hash.0.len());
+        match multibase::decode(ui_string_hash.0) {
+            Ok((_, bytes)) => Ok(Self(holo_hash::DnaHash::from_raw_36_and_type(bytes, holo_hash::hash_type::Dna))),
+            Err(e) => Err(format!("{:?}", e)),
+        }
+    }
+}
+impl From<SafeWrappedDnaHash> for HashString {
+    fn from(wrapped_dna_hash: SafeWrappedDnaHash) -> Self {
+        Self(multibase::encode(multibase::Base::Base32Lower, &wrapped_dna_hash.0.get_raw_39()[3..]).to_string())
+    }
+}


### PR DESCRIPTION
### Summary:
`SafeWrapped_` will create a string of length 63 char
 
- Header: `hckk...`
- Entry: `hcek...`
- Agent: `hcak...`
- Dna: `hc0k...`